### PR TITLE
Chore/release 2025.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 All notable changes to this project are documented in this file.
 
+### 2025.3.1 (2025-09-16) - release
+- Small documentation and packaging fixes; updated README badge to point at raw GitHub URL so PyPI can render the in-repo coverage badge.
+ 
+
 ### 2025.3.0 (2025-09-16) - chore/update-tests & feature work
 - Added per-Python-version CI workflows and badges (3.10–3.13) and updated the central `ci.yml` lint/typecheck workflow.
 - Implemented an in-repo coverage badge generator workflow and accompanying script that creates `docs/coverage-badge.svg` and opens/updates an idempotent PR (`coverage-badge-update`).
@@ -17,6 +21,7 @@ All notable changes to this project are documented in this file.
 - Renamed tests using splurge-test-namer tool.
 - Added DOMAINS list to each code module.
 - Replaced inline coverage parsing in the coverage-badge workflow with a committed script `tools/generate_coverage_badge.py` for robustness.
+
 
 ### 2025.2.0 (2025-09-03)
 - Added domain exceptions at CLI boundary: `ConfigError`, `DataSourceError`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ exclude = ["tests*", "examples*", "plans*", "docs*"]
 
 [project]
 name = "splurge-lazyframe-compare"
-version = "2025.3.0"
+version = "2025.3.1"
 description = "A Python package for comparing splurge and lazyframe functionality"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
This pull request includes a minor release with small documentation and packaging fixes. The main changes are updates to the `CHANGELOG.md` and `pyproject.toml` to reflect the new version and improved badge rendering for PyPI.

Release and documentation updates:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR6-R9): Added a new release entry for version `2025.3.1`, noting small documentation and packaging fixes, and updated the README badge to use a raw GitHub URL for better coverage badge rendering on PyPI.
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L11-R11): Bumped the package version from `2025.3.0` to `2025.3.1`.